### PR TITLE
chore(deps): update dependencies - Updated Python to 3.14-slim in Doc…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.14"
 
       - name: Install dependencies
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use Python 3.11 slim image
-FROM python:3.11-slim
+# Use Python 3.14 slim image
+FROM python:3.14-slim
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
This PR resolves all dependency updates from the Renovate Dashboard (issue #11).

Changes Made
Dockerfile: Updated Python base image 3.11-slim → 3.14-slim
CI Workflow ([ci.yml](vscode-file://vscode-app/c:/Users/sc895/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)):
actions/checkout@v4 → v6
actions/setup-python@v4 → v6
Python version 3.10 → 3.14