### PR TITLE
MX-149: Add unit tests for MCP Auth and Client self-service tools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ fastmcp
 fastapi-mcp
 black
 flake8
+pytest
+pytest-asyncio
+pytest-cov

--- a/tests/test_auth_tools.py
+++ b/tests/test_auth_tools.py
@@ -1,0 +1,113 @@
+import pytest
+from unittest.mock import patch, AsyncMock
+from routers.auth_tools import (
+    register_self_service,
+    confirm_registration,
+    login_mifos,
+    confirm_registration_get,
+    update_password_self,
+    verify_user_registration_alias,
+    authenticate_user_alias,
+)
+
+
+@pytest.mark.asyncio
+@patch("routers.auth_tools.make_request", new_callable=AsyncMock)
+async def test_register_self_service(mock_make_request):
+    mock_make_request.return_value = {"status": "success"}
+    result = await register_self_service(
+        username="user1",
+        accountNumber="123",
+        password="pwd",
+        firstName="John",
+        middleName="Robert",
+        lastName="Doe",
+        mobileNumber="1234567890",
+        email="john@example.com",
+        authenticationMode="email",
+    )
+    assert result == {"status": "success"}
+    mock_make_request.assert_called_once_with(
+        "POST",
+        "/self/registration",
+        data={
+            "username": "user1",
+            "accountNumber": "123",
+            "password": "pwd",
+            "firstName": "John",
+            "middleName": "Robert",
+            "lastName": "Doe",
+            "mobileNumber": "1234567890",
+            "email": "john@example.com",
+            "authenticationMode": "email",
+        },
+    )
+
+
+@pytest.mark.asyncio
+@patch("routers.auth_tools.make_request", new_callable=AsyncMock)
+async def test_confirm_registration(mock_make_request):
+    mock_make_request.return_value = {"status": "confirmed"}
+    result = await confirm_registration(requestId=1, authenticationToken="token123")
+    assert result == {"status": "confirmed"}
+    mock_make_request.assert_called_once_with(
+        "POST", "/self/registration/user", data={"requestId": 1, "authenticationToken": "token123"}
+    )
+
+
+@pytest.mark.asyncio
+@patch("routers.auth_tools.make_request", new_callable=AsyncMock)
+async def test_login_mifos(mock_make_request):
+    mock_make_request.return_value = {"token": "auth_token"}
+    result = await login_mifos("user1", "pwd")
+    assert result == {"token": "auth_token"}
+    mock_make_request.assert_called_once_with(
+        "POST", "/self/authentication", data={"username": "user1", "password": "pwd"}
+    )
+
+
+@pytest.mark.asyncio
+@patch("routers.auth_tools.make_request", new_callable=AsyncMock)
+@patch("routers.auth_tools.get_auth_header")
+async def test_confirm_registration_get(mock_get_auth_header, mock_make_request):
+    mock_get_auth_header.return_value = "Basic dXNlcjE6cHdk"
+    mock_make_request.return_value = {"clients": []}
+    result = await confirm_registration_get("user1", "pwd")
+    assert result == {"clients": []}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("GET", "/self/clients", auth="Basic dXNlcjE6cHdk")
+
+
+@pytest.mark.asyncio
+@patch("routers.auth_tools.make_request", new_callable=AsyncMock)
+@patch("routers.auth_tools.get_auth_header")
+async def test_update_password_self(mock_get_auth_header, mock_make_request):
+    mock_get_auth_header.return_value = "Basic dXNlcjE6b2xkX3B3ZA=="
+    mock_make_request.return_value = {"status": "updated"}
+    result = await update_password_self("user1", "old_pwd", "new_pwd")
+    assert result == {"status": "updated"}
+    mock_get_auth_header.assert_called_once_with("user1", "old_pwd")
+    mock_make_request.assert_called_once_with(
+        "PUT",
+        "/self/user",
+        auth="Basic dXNlcjE6b2xkX3B3ZA==",
+        data={"password": "old_pwd", "newPassword": "new_pwd", "repeatNewPassword": "new_pwd"},
+    )
+
+
+@pytest.mark.asyncio
+@patch("routers.auth_tools.confirm_registration", new_callable=AsyncMock)
+async def test_verify_user_registration_alias(mock_confirm_registration):
+    mock_confirm_registration.return_value = {"status": "verified"}
+    result = await verify_user_registration_alias(1, "token")
+    assert result == {"status": "verified"}
+    mock_confirm_registration.assert_called_once_with(1, "token")
+
+
+@pytest.mark.asyncio
+@patch("routers.auth_tools.login_mifos", new_callable=AsyncMock)
+async def test_authenticate_user_alias(mock_login_mifos):
+    mock_login_mifos.return_value = {"status": "authenticated"}
+    result = await authenticate_user_alias("user1", "pwd")
+    assert result == {"status": "authenticated"}
+    mock_login_mifos.assert_called_once_with("user1", "pwd")

--- a/tests/test_client_tools.py
+++ b/tests/test_client_tools.py
@@ -1,0 +1,120 @@
+import pytest
+from unittest.mock import patch, AsyncMock
+from routers.client_tools import (
+    get_clients_linked_to_user,
+    get_client_details,
+    get_client_accounts,
+    get_client_images,
+    get_client_charges,
+    get_client_transactions,
+    get_client_transaction_detail,
+)
+
+
+@pytest.fixture
+def mock_auth():
+    return "Basic dXNlcjE6cHdk"
+
+
+@pytest.mark.asyncio
+@patch("routers.client_tools.make_request", new_callable=AsyncMock)
+@patch("routers.client_tools.get_auth_header")
+async def test_get_clients_linked_to_user(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = [{"id": 1}]
+
+    result = await get_clients_linked_to_user("user1", "pwd")
+    assert result == [{"id": 1}]
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("GET", "/self/clients", auth=mock_auth)
+
+
+@pytest.mark.asyncio
+@patch("routers.client_tools.make_request", new_callable=AsyncMock)
+@patch("routers.client_tools.get_auth_header")
+async def test_get_client_details(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"id": 1, "name": "John"}
+
+    result = await get_client_details(1, "user1", "pwd")
+    assert result == {"id": 1, "name": "John"}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("GET", "/self/clients/1", auth=mock_auth)
+
+
+@pytest.mark.asyncio
+@patch("routers.client_tools.make_request", new_callable=AsyncMock)
+@patch("routers.client_tools.get_auth_header")
+async def test_get_client_accounts_without_fields(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"loanAccounts": []}
+
+    result = await get_client_accounts(1, "user1", "pwd")
+    assert result == {"loanAccounts": []}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("GET", "/self/clients/1/accounts", auth=mock_auth)
+
+
+@pytest.mark.asyncio
+@patch("routers.client_tools.make_request", new_callable=AsyncMock)
+@patch("routers.client_tools.get_auth_header")
+async def test_get_client_accounts_with_fields(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"loanAccounts": []}
+
+    result = await get_client_accounts(1, "user1", "pwd", fields="loanAccounts")
+    assert result == {"loanAccounts": []}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("GET", "/self/clients/1/accounts?fields=loanAccounts", auth=mock_auth)
+
+
+@pytest.mark.asyncio
+@patch("routers.client_tools.make_request", new_callable=AsyncMock)
+@patch("routers.client_tools.get_auth_header")
+async def test_get_client_images(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"image": "base64..."}
+
+    result = await get_client_images(1, "user1", "pwd")
+    assert result == {"image": "base64..."}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("GET", "/self/clients/1/images", auth=mock_auth)
+
+
+@pytest.mark.asyncio
+@patch("routers.client_tools.make_request", new_callable=AsyncMock)
+@patch("routers.client_tools.get_auth_header")
+async def test_get_client_charges(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = [{"chargeId": 1}]
+
+    result = await get_client_charges(1, "user1", "pwd")
+    assert result == [{"chargeId": 1}]
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("GET", "/self/clients/1/charges", auth=mock_auth)
+
+
+@pytest.mark.asyncio
+@patch("routers.client_tools.make_request", new_callable=AsyncMock)
+@patch("routers.client_tools.get_auth_header")
+async def test_get_client_transactions(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"pageItems": []}
+
+    result = await get_client_transactions(1, "user1", "pwd", offset=10, limit=5)
+    assert result == {"pageItems": []}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("GET", "/self/clients/1/transactions?offset=10&limit=5", auth=mock_auth)
+
+
+@pytest.mark.asyncio
+@patch("routers.client_tools.make_request", new_callable=AsyncMock)
+@patch("routers.client_tools.get_auth_header")
+async def test_get_client_transaction_detail(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"id": 100}
+
+    result = await get_client_transaction_detail(1, 100, "user1", "pwd")
+    assert result == {"id": 100}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("GET", "/self/clients/1/transactions/100", auth=mock_auth)


### PR DESCRIPTION
## Description

This PR adds the initial test setup for core MCP tools by introducing unit tests for authentication and client-related workflows.

## Changes

- Added `test_auth_tools.py` to test authentication and registration flows.
- Added `test_client_tools.py` to test client details and account retrieval operations.
- Implemented mock-based unit testing using `unittest.mock.patch`.