### PR TITLE
MX-156:Add unit tests for MCP beneficiary, transfer, guarantor self-s…

### DIFF
--- a/tests/test_beneficiary_tools.py
+++ b/tests/test_beneficiary_tools.py
@@ -1,0 +1,111 @@
+import pytest
+from unittest.mock import patch, AsyncMock
+from routers.beneficiary_tools import (
+    get_beneficiary_template,
+    get_beneficiary_list,
+    create_beneficiary_savings,
+    create_beneficiary_loan,
+    update_beneficiary_savings,
+    update_beneficiary_loan,
+    delete_beneficiary,
+)
+
+
+@pytest.fixture
+def mock_auth():
+    return "Basic dXNlcjE6cHdk"
+
+
+@pytest.mark.asyncio
+@patch("routers.beneficiary_tools.make_request", new_callable=AsyncMock)
+@patch("routers.beneficiary_tools.get_auth_header")
+async def test_get_beneficiary_template(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"template": True}
+
+    result = await get_beneficiary_template("user1", "pwd")
+    assert result == {"template": True}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("GET", "/self/beneficiaries/tpt/template", auth=mock_auth)
+
+
+@pytest.mark.asyncio
+@patch("routers.beneficiary_tools.make_request", new_callable=AsyncMock)
+@patch("routers.beneficiary_tools.get_auth_header")
+async def test_get_beneficiary_list(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = [{"id": 1, "name": "Ben"}]
+
+    result = await get_beneficiary_list("user1", "pwd")
+    assert result == [{"id": 1, "name": "Ben"}]
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("GET", "/self/beneficiaries/tpt", auth=mock_auth)
+
+
+@pytest.mark.asyncio
+@patch("routers.beneficiary_tools.make_request", new_callable=AsyncMock)
+@patch("routers.beneficiary_tools.get_auth_header")
+async def test_create_beneficiary_savings(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"resourceId": 1}
+    data = {"name": "Ben"}
+
+    result = await create_beneficiary_savings(data, "user1", "pwd")
+    assert result == {"resourceId": 1}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("POST", "/self/beneficiaries/tpt", auth=mock_auth, data=data)
+
+
+@pytest.mark.asyncio
+@patch("routers.beneficiary_tools.make_request", new_callable=AsyncMock)
+@patch("routers.beneficiary_tools.get_auth_header")
+async def test_create_beneficiary_loan(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"resourceId": 2}
+    data = {"name": "Ben Loan"}
+
+    result = await create_beneficiary_loan(data, "user1", "pwd")
+    assert result == {"resourceId": 2}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("POST", "/self/beneficiaries/tpt", auth=mock_auth, data=data)
+
+
+@pytest.mark.asyncio
+@patch("routers.beneficiary_tools.make_request", new_callable=AsyncMock)
+@patch("routers.beneficiary_tools.get_auth_header")
+async def test_update_beneficiary_savings(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"resourceId": 1}
+    data = {"name": "Ben Updated"}
+
+    result = await update_beneficiary_savings(1, data, "user1", "pwd")
+    assert result == {"resourceId": 1}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("PUT", "/self/beneficiaries/tpt/1", auth=mock_auth, data=data)
+
+
+@pytest.mark.asyncio
+@patch("routers.beneficiary_tools.make_request", new_callable=AsyncMock)
+@patch("routers.beneficiary_tools.get_auth_header")
+async def test_update_beneficiary_loan(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"resourceId": 2}
+    data = {"name": "Ben Loan Updated"}
+
+    result = await update_beneficiary_loan(2, data, "user1", "pwd")
+    assert result == {"resourceId": 2}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("PUT", "/self/beneficiaries/tpt/2", auth=mock_auth, data=data)
+
+
+@pytest.mark.asyncio
+@patch("routers.beneficiary_tools.make_request", new_callable=AsyncMock)
+@patch("routers.beneficiary_tools.get_auth_header")
+async def test_delete_beneficiary(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"resourceId": 3}
+
+    result = await delete_beneficiary(3, "user1", "pwd")
+    assert result == {"resourceId": 3}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("DELETE", "/self/beneficiaries/tpt/3", auth=mock_auth)

--- a/tests/test_guarantor_tools.py
+++ b/tests/test_guarantor_tools.py
@@ -1,0 +1,96 @@
+import pytest
+from unittest.mock import patch, AsyncMock
+from routers.guarantor_tools import (
+    get_guarantor_template,
+    get_loan_guarantors,
+    add_loan_guarantor,
+    update_loan_guarantor,
+    delete_loan_guarantor,
+)
+
+
+@pytest.fixture
+def mock_auth():
+    return "Basic dXNlcjE6cHdk"
+
+
+@pytest.mark.asyncio
+@patch("routers.guarantor_tools.make_request", new_callable=AsyncMock)
+@patch("routers.guarantor_tools.get_auth_header")
+async def test_get_guarantor_template(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"template": True}
+
+    result = await get_guarantor_template(1, "user1", "pwd")
+    assert result == {"template": True}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("GET", "/self/loans/1/guarantors/template", auth=mock_auth)
+
+
+@pytest.mark.asyncio
+@patch("routers.guarantor_tools.make_request", new_callable=AsyncMock)
+@patch("routers.guarantor_tools.get_auth_header")
+async def test_get_loan_guarantors(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = [{"id": 1}]
+
+    result = await get_loan_guarantors(1, "user1", "pwd")
+    assert result == [{"id": 1}]
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("GET", "/self/loans/1/guarantors", auth=mock_auth)
+
+
+@pytest.mark.asyncio
+@patch("routers.guarantor_tools.make_request", new_callable=AsyncMock)
+@patch("routers.guarantor_tools.get_auth_header")
+async def test_add_loan_guarantor(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"resourceId": 2}
+
+    result = await add_loan_guarantor(
+        1, 1, "Guarantor", "Last", "123456", "user1", "pwd", address_line1="123 Street", city="City", zip_code="00000"
+    )
+    assert result == {"resourceId": 2}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with(
+        "POST",
+        "/self/loans/1/guarantors",
+        auth=mock_auth,
+        data={
+            "guarantorType": 1,
+            "firstName": "Guarantor",
+            "lastName": "Last",
+            "mobileNumber": "123456",
+            "addressLine1": "123 Street",
+            "city": "City",
+            "zip": "00000",
+            "locale": "en",
+        },
+    )
+
+
+@pytest.mark.asyncio
+@patch("routers.guarantor_tools.make_request", new_callable=AsyncMock)
+@patch("routers.guarantor_tools.get_auth_header")
+async def test_update_loan_guarantor(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"resourceId": 1}
+    data = {"firstName": "Updated"}
+
+    result = await update_loan_guarantor(1, 1, data, "user1", "pwd")
+    assert result == {"resourceId": 1}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("PUT", "/self/loans/1/guarantors/1", auth=mock_auth, data=data)
+
+
+@pytest.mark.asyncio
+@patch("routers.guarantor_tools.make_request", new_callable=AsyncMock)
+@patch("routers.guarantor_tools.get_auth_header")
+async def test_delete_loan_guarantor(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"resourceId": 3}
+
+    result = await delete_loan_guarantor(1, 3, "user1", "pwd")
+    assert result == {"resourceId": 3}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("DELETE", "/self/loans/1/guarantors/3", auth=mock_auth)

--- a/tests/test_transfer_tools.py
+++ b/tests/test_transfer_tools.py
@@ -1,0 +1,113 @@
+import pytest
+from unittest.mock import patch, AsyncMock
+from routers.transfer_tools import (
+    get_transfer_template,
+    transfer_between_accounts,
+    transfer_third_party,
+    get_account_transfer_template,
+    get_third_party_transfer_template,
+    make_third_party_transfer,
+    make_account_transfer,
+)
+
+
+@pytest.fixture
+def mock_auth():
+    return "Basic dXNlcjE6cHdk"
+
+
+@pytest.mark.asyncio
+@patch("routers.transfer_tools.make_request", new_callable=AsyncMock)
+@patch("routers.transfer_tools.get_auth_header")
+async def test_get_transfer_template(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"template": True}
+
+    result = await get_transfer_template("user1", "pwd")
+    assert result == {"template": True}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("GET", "/self/accounttransfers/template?type=tpt", auth=mock_auth)
+
+
+@pytest.mark.asyncio
+@patch("routers.transfer_tools.make_request", new_callable=AsyncMock)
+@patch("routers.transfer_tools.get_auth_header")
+async def test_transfer_between_accounts(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"resourceId": 1}
+
+    result = await transfer_between_accounts({"amount": 100}, "user1", "pwd")
+    assert result == {"resourceId": 1}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("POST", "/self/accounttransfers", auth=mock_auth, data={"amount": 100})
+
+
+@pytest.mark.asyncio
+@patch("routers.transfer_tools.make_request", new_callable=AsyncMock)
+@patch("routers.transfer_tools.get_auth_header")
+async def test_transfer_third_party(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"resourceId": 2}
+
+    result = await transfer_third_party({"amount": 200}, "user1", "pwd")
+    assert result == {"resourceId": 2}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with(
+        "POST", "/self/accounttransfers?type=tpt", auth=mock_auth, data={"amount": 200}
+    )
+
+
+@pytest.mark.asyncio
+@patch("routers.transfer_tools.make_request", new_callable=AsyncMock)
+@patch("routers.transfer_tools.get_auth_header")
+async def test_get_account_transfer_template(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"template": True}
+
+    result = await get_account_transfer_template(10, "user1", "pwd")
+    assert result == {"template": True}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with(
+        "GET", "/self/accounttransfers/template?fromAccountId=10&fromAccountType=2", auth=mock_auth
+    )
+
+
+@pytest.mark.asyncio
+@patch("routers.transfer_tools.make_request", new_callable=AsyncMock)
+@patch("routers.transfer_tools.get_auth_header")
+async def test_get_third_party_transfer_template(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"template": True}
+
+    result = await get_third_party_transfer_template("user1", "pwd")
+    assert result == {"template": True}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("GET", "/self/accounttransfers/template?type=tpt", auth=mock_auth)
+
+
+@pytest.mark.asyncio
+@patch("routers.transfer_tools.make_request", new_callable=AsyncMock)
+@patch("routers.transfer_tools.get_auth_header")
+async def test_make_third_party_transfer(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"resourceId": 3}
+
+    result = await make_third_party_transfer({"amount": 300}, "user1", "pwd")
+    assert result == {"resourceId": 3}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with(
+        "POST", "/self/accounttransfers?type=tpt", auth=mock_auth, data={"amount": 300}
+    )
+
+
+@pytest.mark.asyncio
+@patch("routers.transfer_tools.make_request", new_callable=AsyncMock)
+@patch("routers.transfer_tools.get_auth_header")
+async def test_make_account_transfer(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"resourceId": 4}
+
+    result = await make_account_transfer({"amount": 400}, "user1", "pwd")
+    assert result == {"resourceId": 4}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("POST", "/self/accounttransfers", auth=mock_auth, data={"amount": 400})


### PR DESCRIPTION
### Description
This PR resolves by adding unit test coverage for MCP self-service tools related to beneficiaries, transfers, and guarantors.

### Key Changes
- **Beneficiary Tools:** Added `test_beneficiary_tools.py` to validate create, retrieve, update, and delete operations for loan and savings beneficiaries.
- **Transfer Tools:** Added `test_transfer_tools.py` to verify account and third-party transfer functionalities.
- **Guarantor Tools:** Added `test_guarantor_tools.py` to test CRUD operations for managing loan guarantors.

### Testing
- All new test suites pass locally using `pytest`.