### PR TITLE
feat: enhance CI with ruff, bandit, coverage reporting, and strict mypy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,18 +38,24 @@ jobs:
       - name: Check Formatting (Black)
         run: black --check .
 
+      - name: Run Linting (Ruff)
+        run: ruff check .
+
       - name: Run Linting (Flake8)
         run: flake8 .
 
       - name: Run Static Type Checking (mypy)
-        run: mypy --explicit-package-bases . || true  # Using '|| true' temporarily so it doesn't break until typings are fully fixed
+        run: mypy --explicit-package-bases .
 
-      - name: Run Unit Tests (pytest)
+      - name: Run Security Scan (Bandit)
+        run: bandit -r . --exclude ./.venv,./venv,./tests -q
+
+      - name: Run Unit Tests with Coverage (pytest)
         env:
           MIFOS_BASE_URL: https://tt.mifos.community
           MIFOS_TENANT: default
           PYTHONPATH: .
-        run: python -m pytest
+        run: python -m pytest --cov=. --cov-report=term-missing --cov-fail-under=50
 
       - name: Run MCP Smoke Check
         env:

--- a/config/config.py
+++ b/config/config.py
@@ -1,4 +1,5 @@
 import os
+
 from dotenv import load_dotenv
 
 load_dotenv()

--- a/local_test.sh
+++ b/local_test.sh
@@ -24,24 +24,32 @@ echo "Installing dependencies..."
 python -m pip install --upgrade pip
 python -m pip install -r requirements.txt
 
-# 3. Run linting
+# 3. Run linting (Ruff)
+echo "Running ruff linting..."
+ruff check .
+
+# 4. Run linting (Flake8)
 echo "Running flake8 linting..."
 flake8 .
 
-# 4. Check formatting
+# 5. Check formatting
 echo "Checking formatting with black..."
 black --check .
 
-# 5. Run type checking
+# 6. Run type checking
 echo "Running mypy type checking..."
-mypy --explicit-package-bases . || true  # Let it pass for now even if there are errors, to introduce it smoothly
+mypy --explicit-package-bases .
 
-# 6. Run unit tests
-echo "Running pytest..."
+# 7. Run security scan
+echo "Running bandit security scan..."
+bandit -r . --exclude ./.venv,./venv,./tests -q
+
+# 8. Run unit tests with coverage
+echo "Running pytest with coverage..."
 export PYTHONPATH=.
-python -m pytest
+python -m pytest --cov=. --cov-report=term-missing --cov-fail-under=50
 
-# 7. MCP smoke check
+# 9. MCP smoke check
 echo "Running MCP smoke check..."
 python -c "
 import os, importlib
@@ -57,7 +65,7 @@ assert hasattr(m, 'mcp'), 'MCP instance not found in main module'
 
 # Test that router modules can be imported (this will register the tools)
 import routers.auth_tools
-import routers.client_tools  
+import routers.client_tools
 import routers.beneficiary_tools
 import routers.transfer_tools
 import resources.overview
@@ -65,6 +73,6 @@ import resources.endpoints
 import resources.workflows
 
 print('MCP server imported and router modules loaded successfully.')
-" 
+"
 
 echo "=== All checks passed! ==="

--- a/main.py
+++ b/main.py
@@ -1,21 +1,21 @@
-from mcp_app import mcp
-from config.config import BASE_URL, DEFAULT_TENANT
-
-# Register MCP tools (imports are required for side-effects)
-import routers.auth_tools  # noqa: F401
-import routers.client_tools  # noqa: F401
-import routers.beneficiary_tools  # noqa: F401
-import routers.transfer_tools  # noqa: F401
-import routers.loan_tools  # noqa: F401
-import routers.savings_tools  # noqa: F401
-import routers.guarantor_tools  # noqa: F401
-import routers.shares_tools  # noqa: F401
-import routers.notification_tools  # noqa: F401
+import resources.endpoints  # noqa: F401
 
 # Register MCP resources
 import resources.overview  # noqa: F401
-import resources.endpoints  # noqa: F401
 import resources.workflows  # noqa: F401
+
+# Register MCP tools (imports are required for side-effects)
+import routers.auth_tools  # noqa: F401
+import routers.beneficiary_tools  # noqa: F401
+import routers.client_tools  # noqa: F401
+import routers.guarantor_tools  # noqa: F401
+import routers.loan_tools  # noqa: F401
+import routers.notification_tools  # noqa: F401
+import routers.savings_tools  # noqa: F401
+import routers.shares_tools  # noqa: F401
+import routers.transfer_tools  # noqa: F401
+from config.config import BASE_URL, DEFAULT_TENANT
+from mcp_app import mcp
 
 if __name__ == "__main__":
     print("Starting TT Mobile Banking MCP Server")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,14 @@ exclude = '''
 | dist
 )/
 '''
+
+[tool.ruff]
+line-length = 120
+exclude = [".git", "__pycache__", "build", "dist", "venv", ".venv"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W"]
+ignore = ["E203"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,9 @@ fastmcp
 fastapi-mcp
 black
 flake8
+ruff
 pytest
 pytest-asyncio
 pytest-cov
 mypy
+bandit

--- a/resources/endpoints.py
+++ b/resources/endpoints.py
@@ -6,25 +6,25 @@ async def get_endpoints() -> str:
     """List of available API endpoints"""
     return """
     # Available API Endpoints
-    
+
     ## Registration & Authentication
     - POST /self/registration - Register new self-service user
     - POST /self/registration/user - Confirm registration
     - POST /self/authentication - Login
-    
+
     ## Client Information
     - GET /self/clients - Get client details
     - GET /self/clients/{id}/accounts - List accounts
     - GET /self/clients/{id}/charges - List charges
     - GET /self/clients/{id}/transactions - List transactions
-    
+
     ## Beneficiaries
     - GET /self/beneficiaries/tpt - List beneficiaries
     - GET /self/beneficiaries/tpt/{accountNumber} - Get beneficiary template
     - POST /self/beneficiaries/tpt - Add beneficiary
     - PUT /self/beneficiaries/tpt/{id} - Update beneficiary
     - DELETE /self/beneficiaries/tpt/{id} - Delete beneficiary
-    
+
     ## Transfers
     - GET /self/accounttransfers/template?type="tpt" - Transfer template
     - POST /self/accounttransfers?type="tpt" - Make transfer

--- a/resources/overview.py
+++ b/resources/overview.py
@@ -6,31 +6,31 @@ async def get_overview() -> str:
     """Overview of TT Mobile Banking API capabilities"""
     return """
     # TT Mobile Banking API Overview
-    
+
     This MCP server provides access to the TT Mobile Banking API, which includes:
-    
+
     ## User Management
     - Self-service registration for existing clients
     - Registration confirmation with authentication tokens
     - Secure login with username/password
-    
+
     ## Account Management
     - View client information
     - List all accounts (savings, loans)
     - View account charges
     - View transaction history
-    
+
     ## Beneficiary Management
     - Add beneficiaries for third-party transfers
     - Update beneficiary details and limits
     - Delete beneficiaries
     - View beneficiary list
-    
+
     ## Transfers
     - Third-party transfers between accounts
     - Support for both savings and loan accounts
     - Transfer limits and descriptions
-    
+
     ## Security
     - Basic authentication for API calls
     - Tenant-based isolation

--- a/routers/auth_tools.py
+++ b/routers/auth_tools.py
@@ -1,7 +1,8 @@
+from typing import Any, Dict, Optional
+
 from mcp_app import mcp
-from typing import Dict, Any, Optional
-from utils.http import make_request
 from utils.auth import get_auth_header
+from utils.http import make_request
 
 
 @mcp.tool(name="register_self_service_existing_client")

--- a/routers/beneficiary_tools.py
+++ b/routers/beneficiary_tools.py
@@ -1,7 +1,8 @@
+from typing import Any, Dict
+
 from mcp_app import mcp
-from typing import Dict, Any
-from utils.http import make_request
 from utils.auth import get_auth_header
+from utils.http import make_request
 
 
 @mcp.tool(name="get_beneficiary_template")

--- a/routers/client_tools.py
+++ b/routers/client_tools.py
@@ -1,7 +1,8 @@
+from typing import Any, Dict, Optional
+
 from mcp_app import mcp
-from typing import Dict, Any, Optional
-from utils.http import make_request
 from utils.auth import get_auth_header
+from utils.http import make_request
 
 
 @mcp.tool(name="get_clients_linked_to_user")

--- a/routers/guarantor_tools.py
+++ b/routers/guarantor_tools.py
@@ -1,7 +1,8 @@
+from typing import Any, Dict, Optional
+
 from mcp_app import mcp
-from typing import Dict, Any, Optional
-from utils.http import make_request
 from utils.auth import get_auth_header
+from utils.http import make_request
 
 
 @mcp.tool(name="get_guarantor_template")

--- a/routers/loan_tools.py
+++ b/routers/loan_tools.py
@@ -1,7 +1,8 @@
+from typing import Any, Dict, Optional
+
 from mcp_app import mcp
-from typing import Dict, Any, Optional
-from utils.http import make_request
 from utils.auth import get_auth_header
+from utils.http import make_request
 
 
 @mcp.tool(name="get_loan_products")

--- a/routers/notification_tools.py
+++ b/routers/notification_tools.py
@@ -1,7 +1,8 @@
+from typing import Any, Dict
+
 from mcp_app import mcp
-from typing import Dict, Any
-from utils.http import make_request
 from utils.auth import get_auth_header
+from utils.http import make_request
 
 
 @mcp.tool(name="get_user_notification_details")

--- a/routers/savings_tools.py
+++ b/routers/savings_tools.py
@@ -1,7 +1,8 @@
+from typing import Any, Dict, Optional
+
 from mcp_app import mcp
-from typing import Dict, Any, Optional
-from utils.http import make_request
 from utils.auth import get_auth_header
+from utils.http import make_request
 
 
 @mcp.tool(name="get_savings_products")

--- a/routers/shares_tools.py
+++ b/routers/shares_tools.py
@@ -1,7 +1,8 @@
+from typing import Any, Dict
+
 from mcp_app import mcp
-from typing import Dict, Any
-from utils.http import make_request
 from utils.auth import get_auth_header
+from utils.http import make_request
 
 
 @mcp.tool(name="get_share_product_list")

--- a/routers/transfer_tools.py
+++ b/routers/transfer_tools.py
@@ -1,7 +1,8 @@
+from typing import Any, Dict
+
 from mcp_app import mcp
-from typing import Dict, Any
-from utils.http import make_request
 from utils.auth import get_auth_header
+from utils.http import make_request
 
 
 @mcp.tool(name="transfer_to_third_party_template")

--- a/tests/test_auth_tools.py
+++ b/tests/test_auth_tools.py
@@ -1,13 +1,15 @@
+from unittest.mock import AsyncMock, patch
+
 import pytest
-from unittest.mock import patch, AsyncMock
+
 from routers.auth_tools import (
-    register_self_service,
+    authenticate_user_alias,
     confirm_registration,
-    login_mifos,
     confirm_registration_get,
+    login_mifos,
+    register_self_service,
     update_password_self,
     verify_user_registration_alias,
-    authenticate_user_alias,
 )
 
 

--- a/tests/test_beneficiary_tools.py
+++ b/tests/test_beneficiary_tools.py
@@ -1,13 +1,15 @@
+from unittest.mock import AsyncMock, patch
+
 import pytest
-from unittest.mock import patch, AsyncMock
+
 from routers.beneficiary_tools import (
-    get_beneficiary_template,
-    get_beneficiary_list,
-    create_beneficiary_savings,
     create_beneficiary_loan,
-    update_beneficiary_savings,
-    update_beneficiary_loan,
+    create_beneficiary_savings,
     delete_beneficiary,
+    get_beneficiary_list,
+    get_beneficiary_template,
+    update_beneficiary_loan,
+    update_beneficiary_savings,
 )
 
 

--- a/tests/test_client_tools.py
+++ b/tests/test_client_tools.py
@@ -1,13 +1,15 @@
+from unittest.mock import AsyncMock, patch
+
 import pytest
-from unittest.mock import patch, AsyncMock
+
 from routers.client_tools import (
-    get_clients_linked_to_user,
-    get_client_details,
     get_client_accounts,
-    get_client_images,
     get_client_charges,
-    get_client_transactions,
+    get_client_details,
+    get_client_images,
     get_client_transaction_detail,
+    get_client_transactions,
+    get_clients_linked_to_user,
 )
 
 

--- a/tests/test_guarantor_tools.py
+++ b/tests/test_guarantor_tools.py
@@ -1,11 +1,13 @@
+from unittest.mock import AsyncMock, patch
+
 import pytest
-from unittest.mock import patch, AsyncMock
+
 from routers.guarantor_tools import (
+    add_loan_guarantor,
+    delete_loan_guarantor,
     get_guarantor_template,
     get_loan_guarantors,
-    add_loan_guarantor,
     update_loan_guarantor,
-    delete_loan_guarantor,
 )
 
 

--- a/tests/test_loan_tools.py
+++ b/tests/test_loan_tools.py
@@ -1,13 +1,15 @@
+from unittest.mock import AsyncMock, patch
+
 import pytest
-from unittest.mock import patch, AsyncMock
+
 from routers.loan_tools import (
-    get_loan_products,
-    get_loan_product_details,
-    get_loan_account_details,
-    get_loan_transaction_detail,
-    get_loan_account_charges,
-    get_loan_template,
     calculate_loan_repayment_calendar,
+    get_loan_account_charges,
+    get_loan_account_details,
+    get_loan_product_details,
+    get_loan_products,
+    get_loan_template,
+    get_loan_transaction_detail,
     submit_loan_application,
     update_loan_application,
     withdraw_loan_application,

--- a/tests/test_savings_tools.py
+++ b/tests/test_savings_tools.py
@@ -1,13 +1,15 @@
+from unittest.mock import AsyncMock, patch
+
 import pytest
-from unittest.mock import patch, AsyncMock
+
 from routers.savings_tools import (
-    get_savings_products,
-    get_savings_product_details,
-    get_savings_details,
-    get_savings_transactions,
-    get_savings_transaction_details,
     get_savings_charges,
+    get_savings_details,
+    get_savings_product_details,
+    get_savings_products,
     get_savings_template_raw,
+    get_savings_transaction_details,
+    get_savings_transactions,
     submit_savings_application,
     update_savings_application,
 )

--- a/tests/test_transfer_tools.py
+++ b/tests/test_transfer_tools.py
@@ -1,13 +1,15 @@
+from unittest.mock import AsyncMock, patch
+
 import pytest
-from unittest.mock import patch, AsyncMock
+
 from routers.transfer_tools import (
-    get_transfer_template,
-    transfer_between_accounts,
-    transfer_third_party,
     get_account_transfer_template,
     get_third_party_transfer_template,
-    make_third_party_transfer,
+    get_transfer_template,
     make_account_transfer,
+    make_third_party_transfer,
+    transfer_between_accounts,
+    transfer_third_party,
 )
 
 

--- a/utils/http.py
+++ b/utils/http.py
@@ -1,6 +1,8 @@
+from typing import Any, Dict, Optional
+
 import httpx
-from typing import Optional, Dict, Any
-from config.config import BASE_URL, API_BASE_PATH, DEFAULT_TENANT
+
+from config.config import API_BASE_PATH, BASE_URL, DEFAULT_TENANT
 
 
 async def make_request(


### PR DESCRIPTION
Adds the remaining CI pipelines the issue #26 called for, ruff, security scanning, and coverage reporting and removes the mypy bypass.
https://mifosforge.jira.com/browse/AI-198

Issue #26 

### What's new
- **Ruff**: Fast linter + import sorter, configured in `pyproject.toml`
- **Bandit**: Security scanner for hardcoded secrets & insecure defaults (excludes `tests/` to avoid false positives)
- **pytest-cov**: Test coverage reporting with `--cov-fail-under=50` threshold
- **mypy**: Removed `|| true` bypass, now runs strict (passes clean)


### Other changes

- Updated `local_test.sh` to mirror the CI pipeline
- Added `ruff` and `bandit` to `requirements.txt`
- Added `[tool.ruff]` and `[tool.pytest.ini_options]` config to `pyproject.toml`

### Codebase fixes to pass new linters

Adding ruff flagged existing issues that needed to be fixed for CI to pass:

- **Import ordering**: Sorted imports across 19 source/test files to comply with ruff's `I001` (isort) rule
- **Trailing whitespace**: Removed blank-line whitespace in `resources/endpoints.py` and `resources/overview.py` (`W293`)

All fixes were auto-applied via `ruff check --fix`, no manual/logic changes to any existing code.

### Verification

- All 53 existing tests pass
- ruff, flake8, black, mypy, bandit all pass clean
