### PR TITLE
fix: improve HTTP error normalization for MCP tools

### DIFF
--- a/utils/http.py
+++ b/utils/http.py
@@ -3,6 +3,88 @@ from typing import Optional, Dict, Any
 from config.config import BASE_URL, API_BASE_PATH, DEFAULT_TENANT
 
 
+def _categorize_status(status_code: int) -> str:
+    """Categorize HTTP status codes into human-readable error categories."""
+    categories = {
+        400: "bad_request",
+        401: "unauthorized",
+        403: "forbidden",
+        404: "not_found",
+        405: "method_not_allowed",
+        408: "timeout",
+        409: "conflict",
+        422: "validation_error",
+        429: "rate_limited",
+        500: "internal_server_error",
+        502: "bad_gateway",
+        503: "service_unavailable",
+        504: "gateway_timeout",
+    }
+    if status_code in categories:
+        return categories[status_code]
+    if 400 <= status_code < 500:
+        return "client_error"
+    if 500 <= status_code < 600:
+        return "server_error"
+    return "unknown_error"
+
+
+def _build_error_response(
+    status_code: int,
+    message: str,
+    method: str,
+    endpoint: str,
+    details: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Build a consistent, AI-friendly error response object."""
+    error_response: Dict[str, Any] = {
+        "error": True,
+        "status_code": status_code,
+        "error_category": _categorize_status(status_code),
+        "message": message,
+        "request_context": {
+            "method": method.upper(),
+            "endpoint": endpoint,
+        },
+    }
+    if details is not None:
+        error_response["details"] = details
+    return error_response
+
+
+def _parse_api_error(response: httpx.Response) -> tuple[str, Optional[Any]]:
+    """Attempt to parse structured JSON error from API response.
+
+    Returns a tuple of (message, details) where details may contain
+    additional structured error information from the API.
+    """
+    try:
+        error_json = response.json()
+        if isinstance(error_json, dict):
+            # Fineract often returns errors with these fields
+            message = (
+                error_json.get("defaultUserMessage")
+                or error_json.get("developerMessage")
+                or error_json.get("message")
+                or error_json.get("error")
+                or response.reason_phrase
+                or "Unknown error"
+            )
+            # Collect structured details if present
+            details = {}
+            if "errors" in error_json:
+                details["errors"] = error_json["errors"]
+            if "httpStatusCode" in error_json:
+                details["httpStatusCode"] = error_json["httpStatusCode"]
+            if "userMessageGlobalisationCode" in error_json:
+                details["code"] = error_json["userMessageGlobalisationCode"]
+            return str(message), details if details else None
+        return str(error_json), None
+    except (ValueError, KeyError):
+        text = response.text.strip()
+        return text if text else (response.reason_phrase or "Unknown error"), None
+
+
 async def make_request(
     method: str,
     endpoint: str,
@@ -10,7 +92,12 @@ async def make_request(
     data: Optional[Dict] = None,
     tenant: str = DEFAULT_TENANT,
 ) -> Dict[str, Any]:
-    """Make HTTP request to the API."""
+    """Make HTTP request to the API.
+
+    Returns a structured response dict. On errors, returns a normalized
+    error object with status code, category, message, request context,
+    and any structured details from the API response.
+    """
     url = f"{BASE_URL}{API_BASE_PATH}{endpoint}"
     headers = {
         "Fineract-Platform-TenantId": tenant,
@@ -22,14 +109,19 @@ async def make_request(
 
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.request(method=method, url=url, headers=headers, json=data)
+            response = await client.request(
+                method=method, url=url, headers=headers, json=data
+            )
 
             if response.status_code >= 400:
-                return {
-                    "error": True,
-                    "status_code": response.status_code,
-                    "message": response.text,
-                }
+                message, details = _parse_api_error(response)
+                return _build_error_response(
+                    status_code=response.status_code,
+                    message=message,
+                    method=method,
+                    endpoint=endpoint,
+                    details=details,
+                )
 
             try:
                 return response.json()
@@ -37,8 +129,23 @@ async def make_request(
                 return {"message": "Success", "status_code": response.status_code}
 
     except httpx.TimeoutException:
-        return {"error": True, "status_code": 408, "message": f"Request timed out for {method} {url}"}
+        return _build_error_response(
+            status_code=408,
+            message="Request timed out",
+            method=method,
+            endpoint=endpoint,
+        )
     except httpx.ConnectError:
-        return {"error": True, "status_code": 503, "message": f"Cannot connect to server: {url}"}
+        return _build_error_response(
+            status_code=503,
+            message=f"Cannot connect to server: {url}",
+            method=method,
+            endpoint=endpoint,
+        )
     except Exception as e:
-        return {"error": True, "status_code": 500, "message": str(e)}
+        return _build_error_response(
+            status_code=500,
+            message=str(e),
+            method=method,
+            endpoint=endpoint,
+        )


### PR DESCRIPTION
## Summary

This PR improves the HTTP error handling in `utils/http.py` to return structured, AI-friendly error responses instead of raw text. This directly addresses the need described in #5 for better error normalization.

## Changes

### Added helper functions:
- **`_categorize_status(status_code)`** — Maps HTTP status codes to human-readable categories (`bad_request`, `unauthorized`, `not_found`, `validation_error`, etc.)
- **`_build_error_response(status_code, message, method, endpoint, details)`** — Builds consistent error response objects with error category and request context
- **`_parse_api_error(response)`** — Attempts to parse structured JSON error responses from the Fineract API, extracting fields like `defaultUserMessage`, `developerMessage`, `errors` array, and `userMessageGlobalisationCode`

### Improved `make_request()`:
- Returns structured error objects instead of raw `response.text` on HTTP errors
- Includes request context (method, endpoint) in all error responses
- Handles connection errors and timeouts with the same consistent format
- Catches exceptions and wraps them in normalized error objects

## Before (raw text error):
```
"Errors were found: [Validation error on field 'name']"
```

## After (structured error):
```json
{
  "error": true,
  "status_code": 400,
  "error_category": "bad_request",
  "message": "Errors were found: Validation error on field 'name'",
  "request_context": {
    "method": "POST",
    "endpoint": "/clients"
  },
  "details": {
    "errors": [{"field": "name", "code": "validation.msg.invalid"}],
    "code": "validation.msg.client.name.cannot.be.blank"
  }
}
```

## Why this matters for MCP

MCP tools powered by LLMs can now:
1. **Understand what went wrong** via `error_category` without parsing status codes
2. **Retry intelligently** — e.g., skip retries on `unauthorized` but retry on `timeout`
3. **Surface actionable messages** to users via `message` and `details`
4. **Debug issues** with `request_context` showing which endpoint/method failed

Fixes #5