### PR TITLE
fix: add pytest configuration and missing tests for shares and notification toolsfix: add pytest config and missing tests for shares and notification …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,7 @@ exclude = '''
 | dist
 )/
 '''
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+asyncio_mode = "auto"

--- a/tests/test_notification_tools.py
+++ b/tests/test_notification_tools.py
@@ -5,33 +5,33 @@ from routers.notification_tools import (
     register_for_notifications,
     update_notification_registration,
 )
- 
- 
+
+
 @pytest.fixture
 def mock_auth():
     return "Basic dXNlcjE6cHdk"
- 
- 
+
+
 @pytest.mark.asyncio
 @patch("routers.notification_tools.make_request", new_callable=AsyncMock)
 @patch("routers.notification_tools.get_auth_header")
 async def test_get_user_notification_details(mock_get_auth_header, mock_make_request, mock_auth):
     mock_get_auth_header.return_value = mock_auth
     mock_make_request.return_value = {"clientId": 1, "registrationId": "abc123", "platform": "android"}
- 
+
     result = await get_notification_registration_details(1, "user1", "pwd")
     assert result == {"clientId": 1, "registrationId": "abc123", "platform": "android"}
     mock_get_auth_header.assert_called_once_with("user1", "pwd")
     mock_make_request.assert_called_once_with("GET", "/self/device/registration/client/1", auth=mock_auth)
- 
- 
+
+
 @pytest.mark.asyncio
 @patch("routers.notification_tools.make_request", new_callable=AsyncMock)
 @patch("routers.notification_tools.get_auth_header")
 async def test_register_for_notifications_android(mock_get_auth_header, mock_make_request, mock_auth):
     mock_get_auth_header.return_value = mock_auth
     mock_make_request.return_value = {"resourceId": 10}
- 
+
     result = await register_for_notifications(1, "token_xyz", "user1", "pwd", platform="android")
     assert result == {"resourceId": 10}
     mock_get_auth_header.assert_called_once_with("user1", "pwd")
@@ -41,15 +41,15 @@ async def test_register_for_notifications_android(mock_get_auth_header, mock_mak
         auth=mock_auth,
         data={"clientId": 1, "registrationId": "token_xyz", "platform": "android"},
     )
- 
- 
+
+
 @pytest.mark.asyncio
 @patch("routers.notification_tools.make_request", new_callable=AsyncMock)
 @patch("routers.notification_tools.get_auth_header")
 async def test_register_for_notifications_default_platform(mock_get_auth_header, mock_make_request, mock_auth):
     mock_get_auth_header.return_value = mock_auth
     mock_make_request.return_value = {"resourceId": 11}
- 
+
     # Call without specifying platform — should default to "android"
     result = await register_for_notifications(2, "token_abc", "user1", "pwd")
     assert result == {"resourceId": 11}
@@ -59,15 +59,15 @@ async def test_register_for_notifications_default_platform(mock_get_auth_header,
         auth=mock_auth,
         data={"clientId": 2, "registrationId": "token_abc", "platform": "android"},
     )
- 
- 
+
+
 @pytest.mark.asyncio
 @patch("routers.notification_tools.make_request", new_callable=AsyncMock)
 @patch("routers.notification_tools.get_auth_header")
 async def test_register_for_notifications_ios(mock_get_auth_header, mock_make_request, mock_auth):
     mock_get_auth_header.return_value = mock_auth
     mock_make_request.return_value = {"resourceId": 12}
- 
+
     result = await register_for_notifications(3, "ios_token_123", "user1", "pwd", platform="ios")
     assert result == {"resourceId": 12}
     mock_make_request.assert_called_once_with(
@@ -76,15 +76,15 @@ async def test_register_for_notifications_ios(mock_get_auth_header, mock_make_re
         auth=mock_auth,
         data={"clientId": 3, "registrationId": "ios_token_123", "platform": "ios"},
     )
- 
- 
+
+
 @pytest.mark.asyncio
 @patch("routers.notification_tools.make_request", new_callable=AsyncMock)
 @patch("routers.notification_tools.get_auth_header")
 async def test_update_notification_registration(mock_get_auth_header, mock_make_request, mock_auth):
     mock_get_auth_header.return_value = mock_auth
     mock_make_request.return_value = {"resourceId": 10}
- 
+
     result = await update_notification_registration(10, "new_token_xyz", "user1", "pwd", platform="android")
     assert result == {"resourceId": 10}
     mock_get_auth_header.assert_called_once_with("user1", "pwd")
@@ -94,15 +94,15 @@ async def test_update_notification_registration(mock_get_auth_header, mock_make_
         auth=mock_auth,
         data={"registrationId": "new_token_xyz", "platform": "android"},
     )
- 
- 
+
+
 @pytest.mark.asyncio
 @patch("routers.notification_tools.make_request", new_callable=AsyncMock)
 @patch("routers.notification_tools.get_auth_header")
 async def test_update_notification_registration_default_platform(mock_get_auth_header, mock_make_request, mock_auth):
     mock_get_auth_header.return_value = mock_auth
     mock_make_request.return_value = {"resourceId": 10}
- 
+
     # Call without specifying platform — should default to "android"
     result = await update_notification_registration(10, "new_token_xyz", "user1", "pwd")
     assert result == {"resourceId": 10}
@@ -112,28 +112,27 @@ async def test_update_notification_registration_default_platform(mock_get_auth_h
         auth=mock_auth,
         data={"registrationId": "new_token_xyz", "platform": "android"},
     )
- 
- 
+
+
 @pytest.mark.asyncio
 @patch("routers.notification_tools.make_request", new_callable=AsyncMock)
 @patch("routers.notification_tools.get_auth_header")
 async def test_get_user_notification_details_not_found(mock_get_auth_header, mock_make_request, mock_auth):
     mock_get_auth_header.return_value = mock_auth
     mock_make_request.return_value = {"error": True, "status_code": 404, "message": "Client not found"}
- 
+
     result = await get_notification_registration_details(999, "user1", "pwd")
     assert result["error"] is True
     assert result["status_code"] == 404
- 
- 
+
+
 @pytest.mark.asyncio
 @patch("routers.notification_tools.make_request", new_callable=AsyncMock)
 @patch("routers.notification_tools.get_auth_header")
 async def test_register_for_notifications_error(mock_get_auth_header, mock_make_request, mock_auth):
     mock_get_auth_header.return_value = mock_auth
     mock_make_request.return_value = {"error": True, "status_code": 400, "message": "Invalid registration ID"}
- 
+
     result = await register_for_notifications(1, "", "user1", "pwd")
     assert result["error"] is True
     assert result["status_code"] == 400
- 

--- a/tests/test_notification_tools.py
+++ b/tests/test_notification_tools.py
@@ -1,0 +1,139 @@
+import pytest
+from unittest.mock import patch, AsyncMock
+from routers.notification_tools import (
+    get_notification_registration_details,
+    register_for_notifications,
+    update_notification_registration,
+)
+ 
+ 
+@pytest.fixture
+def mock_auth():
+    return "Basic dXNlcjE6cHdk"
+ 
+ 
+@pytest.mark.asyncio
+@patch("routers.notification_tools.make_request", new_callable=AsyncMock)
+@patch("routers.notification_tools.get_auth_header")
+async def test_get_user_notification_details(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"clientId": 1, "registrationId": "abc123", "platform": "android"}
+ 
+    result = await get_notification_registration_details(1, "user1", "pwd")
+    assert result == {"clientId": 1, "registrationId": "abc123", "platform": "android"}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("GET", "/self/device/registration/client/1", auth=mock_auth)
+ 
+ 
+@pytest.mark.asyncio
+@patch("routers.notification_tools.make_request", new_callable=AsyncMock)
+@patch("routers.notification_tools.get_auth_header")
+async def test_register_for_notifications_android(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"resourceId": 10}
+ 
+    result = await register_for_notifications(1, "token_xyz", "user1", "pwd", platform="android")
+    assert result == {"resourceId": 10}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with(
+        "POST",
+        "/self/device/registration",
+        auth=mock_auth,
+        data={"clientId": 1, "registrationId": "token_xyz", "platform": "android"},
+    )
+ 
+ 
+@pytest.mark.asyncio
+@patch("routers.notification_tools.make_request", new_callable=AsyncMock)
+@patch("routers.notification_tools.get_auth_header")
+async def test_register_for_notifications_default_platform(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"resourceId": 11}
+ 
+    # Call without specifying platform — should default to "android"
+    result = await register_for_notifications(2, "token_abc", "user1", "pwd")
+    assert result == {"resourceId": 11}
+    mock_make_request.assert_called_once_with(
+        "POST",
+        "/self/device/registration",
+        auth=mock_auth,
+        data={"clientId": 2, "registrationId": "token_abc", "platform": "android"},
+    )
+ 
+ 
+@pytest.mark.asyncio
+@patch("routers.notification_tools.make_request", new_callable=AsyncMock)
+@patch("routers.notification_tools.get_auth_header")
+async def test_register_for_notifications_ios(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"resourceId": 12}
+ 
+    result = await register_for_notifications(3, "ios_token_123", "user1", "pwd", platform="ios")
+    assert result == {"resourceId": 12}
+    mock_make_request.assert_called_once_with(
+        "POST",
+        "/self/device/registration",
+        auth=mock_auth,
+        data={"clientId": 3, "registrationId": "ios_token_123", "platform": "ios"},
+    )
+ 
+ 
+@pytest.mark.asyncio
+@patch("routers.notification_tools.make_request", new_callable=AsyncMock)
+@patch("routers.notification_tools.get_auth_header")
+async def test_update_notification_registration(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"resourceId": 10}
+ 
+    result = await update_notification_registration(10, "new_token_xyz", "user1", "pwd", platform="android")
+    assert result == {"resourceId": 10}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with(
+        "PUT",
+        "/self/device/registration/10",
+        auth=mock_auth,
+        data={"registrationId": "new_token_xyz", "platform": "android"},
+    )
+ 
+ 
+@pytest.mark.asyncio
+@patch("routers.notification_tools.make_request", new_callable=AsyncMock)
+@patch("routers.notification_tools.get_auth_header")
+async def test_update_notification_registration_default_platform(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"resourceId": 10}
+ 
+    # Call without specifying platform — should default to "android"
+    result = await update_notification_registration(10, "new_token_xyz", "user1", "pwd")
+    assert result == {"resourceId": 10}
+    mock_make_request.assert_called_once_with(
+        "PUT",
+        "/self/device/registration/10",
+        auth=mock_auth,
+        data={"registrationId": "new_token_xyz", "platform": "android"},
+    )
+ 
+ 
+@pytest.mark.asyncio
+@patch("routers.notification_tools.make_request", new_callable=AsyncMock)
+@patch("routers.notification_tools.get_auth_header")
+async def test_get_user_notification_details_not_found(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"error": True, "status_code": 404, "message": "Client not found"}
+ 
+    result = await get_notification_registration_details(999, "user1", "pwd")
+    assert result["error"] is True
+    assert result["status_code"] == 404
+ 
+ 
+@pytest.mark.asyncio
+@patch("routers.notification_tools.make_request", new_callable=AsyncMock)
+@patch("routers.notification_tools.get_auth_header")
+async def test_register_for_notifications_error(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"error": True, "status_code": 400, "message": "Invalid registration ID"}
+ 
+    result = await register_for_notifications(1, "", "user1", "pwd")
+    assert result["error"] is True
+    assert result["status_code"] == 400
+ 

--- a/tests/test_shares_tools.py
+++ b/tests/test_shares_tools.py
@@ -4,73 +4,70 @@ from routers.shares_tools import (
     get_shares_products,
     get_shares_product_details,
 )
- 
- 
+
+
 @pytest.fixture
 def mock_auth():
     return "Basic dXNlcjE6cHdk"
- 
- 
+
+
 @pytest.mark.asyncio
 @patch("routers.shares_tools.make_request", new_callable=AsyncMock)
 @patch("routers.shares_tools.get_auth_header")
 async def test_get_share_product_list(mock_get_auth_header, mock_make_request, mock_auth):
     mock_get_auth_header.return_value = mock_auth
     mock_make_request.return_value = [{"id": 1, "name": "Share Product A"}]
- 
+
     result = await get_shares_products(1, "user1", "pwd")
     assert result == [{"id": 1, "name": "Share Product A"}]
     mock_get_auth_header.assert_called_once_with("user1", "pwd")
     mock_make_request.assert_called_once_with("GET", "/self/products/share?clientId=1", auth=mock_auth)
- 
- 
+
+
 @pytest.mark.asyncio
 @patch("routers.shares_tools.make_request", new_callable=AsyncMock)
 @patch("routers.shares_tools.get_auth_header")
 async def test_get_share_product_details(mock_get_auth_header, mock_make_request, mock_auth):
     mock_get_auth_header.return_value = mock_auth
     mock_make_request.return_value = {"id": 2, "name": "Share Product B", "totalShares": 500}
- 
+
     result = await get_shares_product_details(1, 2, "user1", "pwd")
     assert result == {"id": 2, "name": "Share Product B", "totalShares": 500}
     mock_get_auth_header.assert_called_once_with("user1", "pwd")
-    mock_make_request.assert_called_once_with(
-        "GET", "/self/products/share?clientId=1&productId=2", auth=mock_auth
-    )
- 
- 
+    mock_make_request.assert_called_once_with("GET", "/self/products/share?clientId=1&productId=2", auth=mock_auth)
+
+
 @pytest.mark.asyncio
 @patch("routers.shares_tools.make_request", new_callable=AsyncMock)
 @patch("routers.shares_tools.get_auth_header")
 async def test_get_share_product_list_empty(mock_get_auth_header, mock_make_request, mock_auth):
     mock_get_auth_header.return_value = mock_auth
     mock_make_request.return_value = []
- 
+
     result = await get_shares_products(1, "user1", "pwd")
     assert result == []
     mock_make_request.assert_called_once_with("GET", "/self/products/share?clientId=1", auth=mock_auth)
- 
- 
+
+
 @pytest.mark.asyncio
 @patch("routers.shares_tools.make_request", new_callable=AsyncMock)
 @patch("routers.shares_tools.get_auth_header")
 async def test_get_share_product_list_error(mock_get_auth_header, mock_make_request, mock_auth):
     mock_get_auth_header.return_value = mock_auth
     mock_make_request.return_value = {"error": True, "status_code": 403, "message": "Forbidden"}
- 
+
     result = await get_shares_products(99, "user1", "pwd")
     assert result["error"] is True
     assert result["status_code"] == 403
- 
- 
+
+
 @pytest.mark.asyncio
 @patch("routers.shares_tools.make_request", new_callable=AsyncMock)
 @patch("routers.shares_tools.get_auth_header")
 async def test_get_share_product_details_not_found(mock_get_auth_header, mock_make_request, mock_auth):
     mock_get_auth_header.return_value = mock_auth
     mock_make_request.return_value = {"error": True, "status_code": 404, "message": "Share product not found"}
- 
+
     result = await get_shares_product_details(1, 999, "user1", "pwd")
     assert result["error"] is True
     assert result["status_code"] == 404
- 

--- a/tests/test_shares_tools.py
+++ b/tests/test_shares_tools.py
@@ -1,0 +1,76 @@
+import pytest
+from unittest.mock import patch, AsyncMock
+from routers.shares_tools import (
+    get_shares_products,
+    get_shares_product_details,
+)
+ 
+ 
+@pytest.fixture
+def mock_auth():
+    return "Basic dXNlcjE6cHdk"
+ 
+ 
+@pytest.mark.asyncio
+@patch("routers.shares_tools.make_request", new_callable=AsyncMock)
+@patch("routers.shares_tools.get_auth_header")
+async def test_get_share_product_list(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = [{"id": 1, "name": "Share Product A"}]
+ 
+    result = await get_shares_products(1, "user1", "pwd")
+    assert result == [{"id": 1, "name": "Share Product A"}]
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with("GET", "/self/products/share?clientId=1", auth=mock_auth)
+ 
+ 
+@pytest.mark.asyncio
+@patch("routers.shares_tools.make_request", new_callable=AsyncMock)
+@patch("routers.shares_tools.get_auth_header")
+async def test_get_share_product_details(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"id": 2, "name": "Share Product B", "totalShares": 500}
+ 
+    result = await get_shares_product_details(1, 2, "user1", "pwd")
+    assert result == {"id": 2, "name": "Share Product B", "totalShares": 500}
+    mock_get_auth_header.assert_called_once_with("user1", "pwd")
+    mock_make_request.assert_called_once_with(
+        "GET", "/self/products/share?clientId=1&productId=2", auth=mock_auth
+    )
+ 
+ 
+@pytest.mark.asyncio
+@patch("routers.shares_tools.make_request", new_callable=AsyncMock)
+@patch("routers.shares_tools.get_auth_header")
+async def test_get_share_product_list_empty(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = []
+ 
+    result = await get_shares_products(1, "user1", "pwd")
+    assert result == []
+    mock_make_request.assert_called_once_with("GET", "/self/products/share?clientId=1", auth=mock_auth)
+ 
+ 
+@pytest.mark.asyncio
+@patch("routers.shares_tools.make_request", new_callable=AsyncMock)
+@patch("routers.shares_tools.get_auth_header")
+async def test_get_share_product_list_error(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"error": True, "status_code": 403, "message": "Forbidden"}
+ 
+    result = await get_shares_products(99, "user1", "pwd")
+    assert result["error"] is True
+    assert result["status_code"] == 403
+ 
+ 
+@pytest.mark.asyncio
+@patch("routers.shares_tools.make_request", new_callable=AsyncMock)
+@patch("routers.shares_tools.get_auth_header")
+async def test_get_share_product_details_not_found(mock_get_auth_header, mock_make_request, mock_auth):
+    mock_get_auth_header.return_value = mock_auth
+    mock_make_request.return_value = {"error": True, "status_code": 404, "message": "Share product not found"}
+ 
+    result = await get_shares_product_details(1, 999, "user1", "pwd")
+    assert result["error"] is True
+    assert result["status_code"] == 404
+ 


### PR DESCRIPTION
## Description

While setting up the project locally and running the existing test 
suite, I found that all tests were failing with:
       ModuleNotFoundError: No module named 'routers'

This was because pyproject.toml had no pytest configuration — no 
pythonpath setting to resolve module imports from the project root.

Also noticed shares_tools.py and notification_tools.py were the only 
two router modules without test coverage, so added those as well.

---

## Related Issue

Fixes #38 


---

## Type of Change

Please check the relevant option:

- [x] Bug fix
- [ ] New feature
- [ ] MCP tool enhancement
- [ ] Refactoring / code cleanup
- [ ] Performance improvement
- [ ] Documentation update
- [x] CI / workflow change
- [ ] Other (please specify)

---

## Changes Made

- Added [tool.pytest.ini_options] to pyproject.toml with pythonpath = ["."] 
  to fix ModuleNotFoundError when running tests locally
- Added asyncio_mode = "auto" to support async test execution
- Added tests/test_shares_tools.py with 5 tests covering happy path, 
  empty response, and error cases (403, 404)
- Added tests/test_notification_tools.py with 8 tests covering all three 
  functions, iOS/Android platform variants, default parameter behaviour, 
  and error cases (400, 404)

---

## MCP Tools / API Impact

Does this PR modify or introduce any MCP tools or API endpoints?

- [x] No changes to tools or endpoints
- [ ] New MCP tool added
- [ ] Existing tool updated
- [ ] Existing tool removed


---

## Testing

Please describe how this change was tested.

- [x] Tested locally
- [x] Existing tests pass
- [x] Added new tests
- [ ] Manual API testing performed

Testing details:
- Reproduced the ModuleNotFoundError locally on a fresh venv setup
- Fixed pyproject.toml and confirmed all existing tests now pass
- 13 new tests added across test_shares_tools.py and test_notification_tools.py
- Full test suite passes cleanly after the config fix

## Documentation

- [ ] README updated
- [ ] Tool documentation updated
- [x] No documentation changes required

## Checklist

Before submitting your PR, please ensure:

- [x] Code follows project style guidelines
- [x] The issue scenario was reproduced locally to understand the problem (if applicable)
- [x] Changes are properly tested
- [x] Documentation updated if necessary
- [x] PR title clearly describes the change

---

## Screenshots
All new tests passed:
<img width="1166" height="354" alt="image" src="https://github.com/user-attachments/assets/44bb27c8-99ae-4baa-a344-4e0e292cd0be" />

All tests passed:
<img width="1194" height="620" alt="image" src="https://github.com/user-attachments/assets/1134803c-8374-4cdb-abd8-f5d6ba79c94d" />
<img width="1183" height="475" alt="image" src="https://github.com/user-attachments/assets/ec22bf4d-ed1e-4158-b142-e7de055da4c8" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added async unit tests covering notification registration flows, platform handling (android/ios and default), updates, and error paths.
  * Added async unit tests for shares product listing and detail retrieval, including successful responses, empty results, and error handling.

* **Chores**
  * Updated test configuration to enable asyncio support and adjust Python path for test discovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/mcp-mifosx-self-service/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->